### PR TITLE
Fixed deprecation warnings on “entries-ajax” files

### DIFF
--- a/src/templates/frontend/_questions/entries-ajax.twig
+++ b/src/templates/frontend/_questions/entries-ajax.twig
@@ -1,5 +1,5 @@
 <div class="qarr-entries-set" id="{{ random() }}">
-    {% for question in entries %}
+    {% for question in entries.all() %}
         <div class="qarr-entry-item">
 
             <div class="qarr-entry-content">

--- a/src/templates/frontend/_reviews/entries-ajax.twig
+++ b/src/templates/frontend/_reviews/entries-ajax.twig
@@ -1,5 +1,5 @@
 <div class="qarr-entries-set" id="{{ random() }}">
-    {% for review in entries %}
+    {% for review in entries.all() %}
         <div class="qarr-entry-item">
             <div class="qarr-entry-meta">
                 <div class="qarr-entry-name">{{ review.fullName }}</div>


### PR DESCRIPTION
The deprecation warning say: “Looping through element queries directly has been deprecated. Use the all() function to fetch the query results before looping over them.”