### PR TITLE
Fix permissions on “Configure Elements”

### DIFF
--- a/src/templates/_elements/element-element.twig
+++ b/src/templates/_elements/element-element.twig
@@ -36,7 +36,7 @@
                         <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 20 20"><path d="M0 6c0-1.1.9-2 2-2h3l2-2h6l2 2h3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6zm10 10a5 5 0 1 0 0-10 5 5 0 0 0 0 10zm0-2a3 3 0 1 1 0-6 3 3 0 0 1 0 6z"/></svg>
                     {% endif %}
 
-                    {% if configure %}
+                    {% if configure and currentUser.can('qarr:manageSettings') %}
                         <a href="{{ url('/admin/qarr/settings/configuration') }}" class="configure-element" data-type="{{ entry.elementType }}" data-target="{{  entry.element.type.handle  }}">{{ 'Configure'|t('qarr') }}</a>
                     {% endif %}
                 </div>

--- a/src/templates/_elements/element-sources.twig
+++ b/src/templates/_elements/element-sources.twig
@@ -20,5 +20,10 @@
 
 <div class="button-group">
     <a class="customize-sources"><span class="settings icon"></span></a>
-    <a class="configure-elements btn secondary fullwidth" title="{{ 'Configure Elements'|t('qarr') }}">{{ 'Configure Elements'|t('qarr') }}</a>
+
+    {% if currentUser.can('qarr:manageSettings') %}
+        <a class="configure-elements btn secondary fullwidth">
+            {{ 'Configure Elements'|t('qarr') }}
+        </a>
+    {% endif %}
 </div>


### PR DESCRIPTION
A user without “manage settings” permission cannot configure elements in Reviews and Questions sections